### PR TITLE
Issue #36 - Unescaping description param

### DIFF
--- a/test/test_wts.rb
+++ b/test/test_wts.rb
@@ -97,6 +97,17 @@ class AppTest < Minitest::Test
     assert_equal(200, last_response.status, last_response.body)
   end
 
+  def test_do_pay
+    keygap = login('anna')
+    post('/do-api-token', 'keygap=' + keygap)
+    assert_equal(200, last_response.status, last_response.body)
+    token = last_response.body
+    set_cookie('glogin=')
+    header('X-Zold-WTS', token)
+    post '/do-pay', bnf: 'yegor256', amount: '0.01', details: 'test+API'
+    assert_equal(302, last_response.status, last_response.body)
+  end
+
   private
 
   def login(name)

--- a/wts.rb
+++ b/wts.rb
@@ -36,6 +36,7 @@ require 'zold/remotes'
 require 'zold/amount'
 require 'zold/wallets'
 require 'zold/remotes'
+require 'cgi'
 
 require_relative 'version'
 require_relative 'objects/item'
@@ -270,7 +271,7 @@ post '/do-pay' do
     bnf = friend.item.id
   end
   amount = Zold::Amount.new(zld: params[:amount].to_f)
-  details = params[:details]
+  details = CGI.unescape(params[:details])
   params[:keygap] = params[:pass] if params[:pass]
   keygap = @locals[:keygap].nil? ? params[:keygap] : @locals[:keygap]
   @locals[:ops].pay(keygap, bnf, amount, details)


### PR DESCRIPTION
As requested by issue #36, now the details param is correctly decoded.

Unfortunately, the current architecture doesn't allow for a rigid testing but the solution is working nevertheless. 

I just added a test to verify that my modifications aren't breaking the code.