### PR TITLE
#512 exclude objects/referrals.rb from typos check

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -3,3 +3,6 @@
 
 [default.extend-words]
 Iy = "Iy"
+
+[files]
+extend-exclude = ["objects/referrals.rb"]


### PR DESCRIPTION
Closes #512.

The `typos` CI step on every pull request fails on `objects/referrals.rb`, where `WTS::Referrals::Crypt::ENCODINGS` holds 18 randomly-permuted base64-style alphabets used as obfuscation keys. The substrings `ND` and `Iy` in those permutations get flagged as misspellings of `AND` and `It`, even though the strings are opaque ciphertext keys, not natural-language tokens.

The change adds a `[files] extend-exclude = ["objects/referrals.rb"]` entry to `.github/typos.toml`, scoping the exclusion to the single file whose literals are not prose. Every other file in the tree continues to be checked, and the existing `[default.extend-words]` entry for `Iy` is left in place.

Verified locally with `typos-cli 1.27.0` against the new config: `typos --config .github/typos.toml` exits 0, where the same invocation against the unmodified config emitted the two `ND` and `Iy` warnings observed on master CI.