### PR TITLE
#293 support limit query param in /txns.json

### DIFF
--- a/wts.rb
+++ b/wts.rb
@@ -258,6 +258,11 @@ get '/txns.json' do
   confirmed_user.wallet do |wallet|
     list = wallet.txns
     list.reverse! if params[:sort] && params[:sort] == 'desc'
+    if params[:limit]
+      limit = params[:limit].to_i
+      raise WTS::UserError, "E207: The 'limit' parameter must be a positive integer" if limit <= 0
+      list = list.first(limit)
+    end
     JSON.pretty_generate(
       list.map do |t|
         t.to_json.merge(tid: t.amount.negative? ? "#{wallet.id}:#{t.id}" : "#{t.bnf}:#{t.id}")


### PR DESCRIPTION
Closes #293.

The `/txns.json` route serialised the full wallet transaction history on every call, which the linked issue measured at roughly 17 seconds for a 715-transaction wallet when only the most recent few rows were needed.

The change accepts an optional `limit` query parameter, parses it as an integer after the optional `sort=desc` reverse, and slices the list down to the first `limit` entries before serialising. A non-positive value short-circuits with `WTS::UserError` E207 so a typo never silently returns the entire history.

Locally `ruby -c wts.rb` reports `Syntax OK` and `bundle exec rubocop wts.rb` reports no offences against the project config. The full rake target was not executed in this environment because it requires a live PostgreSQL pool via `DATABASE_URL`; the existing smoke test in `test/test_wts.rb` already hits `/txns.json` without a `limit` parameter and the new branch leaves that no-parameter path unchanged.
