### PR TITLE
#514 map callback row before yielding in repeat_succeeded

### DIFF
--- a/objects/callbacks.rb
+++ b/objects/callbacks.rb
@@ -115,12 +115,13 @@ prefix \"#{prefix}\", regexp #{regexp}, and URI: #{uri}")
   # Repeat all succeeded callbacks.
   def repeat_succeeded
     q = [
-      'SELECT match.id FROM callback',
+      'SELECT callback.*, match.id AS mid FROM callback',
       'JOIN match ON match.callback = callback.id',
       'WHERE match.failure = \'\' AND repeat = true'
     ].join(' ')
     @pgsql.exec(q).each do |r|
-      @pgsql.exec('DELETE FROM match WHERE id = $1', [r['id'].to_i])
+      c = map(r)
+      @pgsql.exec('DELETE FROM match WHERE id = $1', [r['mid'].to_i])
       yield c if block_given?
     end
   end

--- a/test/test_callbacks.rb
+++ b/test/test_callbacks.rb
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2018-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'securerandom'
 require 'zold/amount'
 require 'telepost'
 require_relative 'test__helper'
@@ -44,7 +45,7 @@ class WTS::CallbacksTest < Minitest::Test
     WebMock.allow_net_connect!
     callbacks = WTS::Callbacks.new(t_pgsql, log: t_log)
     id = Zold::Id.new
-    login = 'yegor256'
+    login = "repeat_#{SecureRandom.hex(4)}"
     cid = callbacks.add(login, id.to_s, 'NOPREFIX', /pizza/, 'http://localhost:889/', repeat: true)
     callbacks.restart(cid)
     tid = "#{id}:1"

--- a/test/test_callbacks.rb
+++ b/test/test_callbacks.rb
@@ -32,9 +32,38 @@ class WTS::CallbacksTest < Minitest::Test
       ]
     end
     callbacks.delete_succeeded
-    callbacks.repeat_succeeded
+    repeated = []
+    callbacks.repeat_succeeded { |c| repeated << c }
     callbacks.delete_failed
     callbacks.delete_expired
     assert_requested(get, times: 1)
+    assert_empty(repeated)
+  end
+
+  def test_repeat_succeeded_yields_callback
+    WebMock.allow_net_connect!
+    callbacks = WTS::Callbacks.new(t_pgsql, log: t_log)
+    id = Zold::Id.new
+    login = 'yegor256'
+    cid = callbacks.add(login, id.to_s, 'NOPREFIX', /pizza/, 'http://localhost:889/', repeat: true)
+    callbacks.restart(cid)
+    tid = "#{id}:1"
+    refute_empty(callbacks.match(tid, id.to_s, 'NOPREFIX', 'for pizza'))
+    stub_request(:get, /localhost:889/).to_return(body: 'OK')
+    callbacks.ping do
+      [
+        Zold::Txn.new(
+          1, Time.now,
+          Zold::Amount.new(zld: 1.99),
+          'NOPREFIX',
+          Zold::Id.new, '-'
+        )
+      ]
+    end
+    yielded = []
+    callbacks.repeat_succeeded { |c| yielded << c }
+    assert_equal(1, yielded.count)
+    assert_equal(cid, yielded.first[:id])
+    assert_equal(login, yielded.first[:login])
   end
 end


### PR DESCRIPTION
Closes #514.

`WTS::Callbacks#repeat_succeeded` selected only `match.id` and yielded an unassigned local `c`, so any caller that passed a block raised `NameError: undefined local variable or method 'c'` the first time the loop body fired against a real successful match. The cron in `front/front_callbacks.rb:49` is exactly that caller, so the production path was the broken one.

The change widens the SELECT to `SELECT callback.*, match.id AS mid`, calls `c = map(r)` before the `DELETE`, and switches the DELETE bind to `r['mid']` so it targets the match row rather than the callback row. The shape now mirrors `ping` and the other iterators in the same class. A second Minitest case (`test_repeat_succeeded_yields_callback`) registers a `repeat: true` callback, runs `ping` against a stubbed `OK` endpoint, and asserts the block sees one callback hash with the right `id` and `login`; the existing test was also updated to capture the empty block result so a future regression on the non-yielding path is caught.

Locally `ruby -c objects/callbacks.rb` and `ruby -c test/test_callbacks.rb` report `Syntax OK` and `rubocop` finds no offences across the project. The full `rake` target was not executed in this environment because it requires a live PostgreSQL pool via `DATABASE_URL`; CI will run the suite against the proper fixture.
