### PR TITLE
fix(file_log): require 'fileutils' explicitly to avoid NameError

### DIFF
--- a/objects/file_log.rb
+++ b/objects/file_log.rb
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2018-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fileutils'
+
 class WTS::FileLog
   def initialize(file)
     @file = file


### PR DESCRIPTION
`WTS::FileLog#initialize` at `objects/file_log.rb` calls `FileUtils.mkdir_p(File.dirname(@file))`, but the file did not `require 'fileutils'`. `objects/async_job.rb` already follows the explicit-require pattern at line 5 before calling the same API. Today `WTS::FileLog` happens to load only because some other file in the boot chain pulls the standard library transitively; loaded in isolation, or after an upstream gem stops requiring `fileutils`, it raises `NameError: uninitialized constant WTS::FileLog::FileUtils`.

The change adds `require 'fileutils'` to the top of `objects/file_log.rb`, matching the pattern already in place in `objects/async_job.rb`. After the change, `module WTS; end; require_relative "objects/file_log"; WTS::FileLog.new("/tmp/x/y/z.log")` runs cleanly in a fresh process.

The existing `test/test_file_log.rb` continues to exercise the constructor under `Dir.mktmpdir`; no test changes are needed.

Closes #516
